### PR TITLE
Fix: Dashboard 500 error on npm run dev

### DIFF
--- a/agent_mcp/dashboard/app/globals.css
+++ b/agent_mcp/dashboard/app/globals.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "reactflow/dist/style.css";
 @import "vis-network/styles/vis-network.css";
 
 @custom-variant dark (&:is(.dark *));

--- a/agent_mcp/dashboard/next.config.ts
+++ b/agent_mcp/dashboard/next.config.ts
@@ -6,8 +6,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 })
 
 const nextConfig: NextConfig = {
-  // Enable static export for serving through Python backend
-  output: 'export',
+  // Enable static export for serving through Python backend (only in production)
+  output: process.env.NODE_ENV === 'production' ? 'export' : undefined,
   
   // Configure output directory to be the static folder (only for production builds)
   distDir: process.env.NODE_ENV === 'production' ? '../static' : '.next',


### PR DESCRIPTION
## Problem
  The dashboard throws a 500 Internal Server Error when running \`npm run dev\`.

  ## Root Causes
  1. **Static export in dev mode**: \`next.config.ts\` had \`output: 'export'\` which forces static site generation, incompatible with development mode
  2. **Missing dependency**: \`globals.css\` imports ReactFlow styles but ReactFlow is not installed

  ## Changes
  - Modified \`next.config.ts\` to conditionally set output mode (static export only in production)
  - Removed ReactFlow CSS import from \`globals.css\`

  ## Testing
  Tested locally - dashboard now loads successfully with \`npm run dev\`