### PR TITLE
fix: doc markdown codeblocks

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ mkdir src docs tests
 
 Create `MCD.md` in your project root:
 
-```markdown
+````markdown
 # Task Manager MCD
 
 ## 🎯 Overview & Goals  
@@ -263,7 +263,7 @@ my-task-manager/
 - Data persists across browser sessions
 - No JavaScript errors in console
 - Interface is fully responsive
-```
+````
 
 ### Step 3: Initialize Admin Agent
 

--- a/docs/mcd-guide.md
+++ b/docs/mcd-guide.md
@@ -42,6 +42,7 @@ MCDs are the practical application of **Cognitive Empathy** - understanding that
 ```
 
 **Real Example**:
+
 ```markdown
 ## 🎯 Overview & Goals  
 **Project Vision**: Build a real-time collaborative task management SaaS platform that enables remote teams to track project progress with integrated video communication and file sharing.
@@ -78,6 +79,7 @@ MCDs are the practical application of **Cognitive Empathy** - understanding that
 ```
 
 **Real Example**:
+
 ```markdown
 ## 🏗️ Technical Architecture
 **Frontend**: 
@@ -127,7 +129,8 @@ MCDs are the practical application of **Cognitive Empathy** - understanding that
 ```
 
 **Real Example**:
-```markdown
+
+````markdown
 ## 📋 Detailed Implementation
 
 ### Database Schema
@@ -210,7 +213,7 @@ interface TaskCardProps {
   onStartCall: (taskId: string) => void;
 }
 ```
-```
+````
 
 ### 📁 **4. File Structure & Organization**
 **Purpose**: Guide physical implementation
@@ -224,7 +227,8 @@ interface TaskCardProps {
 ```
 
 **Real Example**:
-```markdown
+
+````markdown
 ## 📁 File Structure & Organization
 
 ### Project Layout
@@ -287,7 +291,7 @@ JWT_SECRET=your-super-secret-key
 AWS_ACCESS_KEY_ID=your-aws-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret
 ```
-```
+````
 
 ### ✅ **5. Task Breakdown & Implementation Plan**
 **Purpose**: Define execution sequence


### PR DESCRIPTION
Such a tiny detail, yet it makes it so much more confusing to get what's prompt markdown vs what's documentation markdown:

I am injecting four-quotes code blocks so that prompt markdown renders properly, rather than both levels getting garbled.